### PR TITLE
modify create-release GitHub action

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -30,7 +30,12 @@ jobs:
           latest_release=$(cat latest_release.txt)
           IFS='.' read -r -a version_parts <<< "${latest_release#v}"
           new_patch_version=$((version_parts[2] + 1))
-          new_version="v${version_parts[0]}.${version_parts[1]}.$new_patch_version"
+          new_minor_version=${version_parts[1]}
+          if [ "$new_patch_version" -ge 10 ]; then
+            new_patch_version=0
+            new_minor_version=$((new_minor_version + 1))
+          fi
+          new_version="v${version_parts[0]}.$new_minor_version.$new_patch_version"
           echo "new_version=$new_version" >> $GITHUB_ENV
 
       - name: Generate release notes
@@ -57,7 +62,7 @@ jobs:
           release_name: "cars-inventory-api ${{ env.new_version }}"
           body: |
             Release notes for ${{ env.new_version }}
-        
+
             ${{ env.release_notes }}
           draft: false
           prerelease: false


### PR DESCRIPTION
This pull request proposes incrementing the minor version by one for every ten patch version increments in creating a new release through the “create-release” GitHub action.