### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/java-custom-ci-maven.yml
+++ b/.github/workflows/java-custom-ci-maven.yml
@@ -12,6 +12,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/sadramesbah/cars-inventory-api/security/code-scanning/2](https://github.com/sadramesbah/cars-inventory-api/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/java-custom-ci-maven.yml` at the workflow root (recommended here since there is only one job and the same restriction should apply globally).

Best minimal fix without changing functionality:
- Insert after the `on:` trigger section (before `jobs:`):
  - `permissions:`
  - `contents: read`

This preserves behavior for checkout/build while ensuring `GITHUB_TOKEN` is restricted to read-only repository contents unless a job overrides it later.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
