### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   create_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sadramesbah/cars-inventory-api/security/code-scanning/1](https://github.com/sadramesbah/cars-inventory-api/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (applies to all jobs) with only the scopes needed by this workflow.  
For this file, the best non-breaking fix is:

- `contents: write` (required to create a GitHub release/tag metadata)
- no additional scopes unless needed by other unseen jobs (none shown)

This change should be made in `.github/workflows/create-release.yml` directly after the trigger section (`on:` block) and before `jobs:`. No imports, methods, or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
